### PR TITLE
Fix .htaccess for Apache >=2.3

### DIFF
--- a/admin/.htaccess
+++ b/admin/.htaccess
@@ -1,4 +1,12 @@
 <Files *>
-	Order Allow,Deny
-	Deny from All
+    # Apache < 2.3
+    <IfModule !mod_authz_core.c>
+        Order Allow,Deny
+        Deny from All
+    </IfModule>
+
+    # Apache ≥ 2.3
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </Files>


### PR DESCRIPTION
Fix .htaccess compatibility with Apache 2.3 and higher because of new Auth module syntax.