### PR TITLE
Do not run channel playback when exit from the plug-ins  (issue #5557)

### DIFF
--- a/c/xpcom.common.js
+++ b/c/xpcom.common.js
@@ -1239,7 +1239,7 @@ function common_xpcom(){
             this.player.init_first_channel();
         }
 
-        if (this.user['display_menu_after_loading'] || !this.player.channels || this.player.channels.length == 0 || !module.tv){
+        if (this.user['display_menu_after_loading'] || focus_module || !this.player.channels || this.player.channels.length == 0 || !module.tv){
             main_menu.show();
             this.on_first_menu_show();
         }else{


### PR DESCRIPTION
Do not run channel playback when exit from the plug-ins  (issue #5557)