### PR TITLE
Don't use gSTB function on browser

### DIFF
--- a/c/xpcom.common.js
+++ b/c/xpcom.common.js
@@ -1052,7 +1052,9 @@ function common_xpcom(){
             stb.ExecAction('reboot');
         }
 
-        gSTB.StandByMode = 1; // always active stand-by
+        if (typeof (gSTB) != 'undefined') {
+            gSTB.StandByMode = 1; // always active stand-by
+        }
 
         screensaver.init();
 


### PR DESCRIPTION
On browser debugging, the whole execution is terminated because gSTB doesn't exists.